### PR TITLE
fix(dependabot): avoid duplicate React type updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,11 @@ updates:
         applies-to: "version-updates"
         patterns:
           - "*"
+        exclude-patterns:
+          # Bun updates these alongside React; processing them again produces
+          # Dependabot::Bun::FileUpdater::NoChangeError.
+          - "@types/react"
+          - "@types/react-dom"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
## Summary

Prevent the Bun Dependabot updater from processing React type packages twice during grouped routine updates. The duplicate pass produced `Dependabot::Bun::FileUpdater::NoChangeError` and made an otherwise successful update job fail.

## Changes

- Exclude `@types/react` and `@types/react-dom` from the `routine-updates` group.
- Keep both packages covered by the unchanged `security-updates` group.
- Preserve the existing weekly Bun schedule and one-PR limit.

## Validation

- Parsed `.github/dependabot.yml` as YAML and asserted the routine exclusions and unchanged security wildcard.
- Ran `bunx prettier --check .github/dependabot.yml`.
- Ran `git diff --check`.
- Confirmed the original failing job reported `NoChangeError` only after Bun had already updated both packages alongside React.

## Breaking changes

None.